### PR TITLE
Add 2fa code autocomplete

### DIFF
--- a/app/views/two_factor_authentication/show.html.erb
+++ b/app/views/two_factor_authentication/show.html.erb
@@ -10,6 +10,6 @@
 
 <%= standard_form(@person, {url: users_two_factor_authentication_confirmation_path, method: 'post'}) do |f| %>
   <%= f.error_messages %>
-  <%= f.labeled_input_field(:second_factor_code, autofocus: true, value: '') %>
+  <%= f.labeled_input_field(:second_factor_code, autofocus: true, autocomplete: 'one-time-code', value: '') %>
   <%= f.indented(submit_button(f, t('.confirm'))) %>
 <% end %>


### PR DESCRIPTION
I am not sure if this is right and cannot test it, but basically adding the attribute `autocomplete="one-time-code"` to the text field should add support for autocompletion of received sms codes:)