### PR TITLE
Monitor sent mails better

### DIFF
--- a/app/domain/sorting_hat.rb
+++ b/app/domain/sorting_hat.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2020, GLP Schweiz. This file is part of
+#  Copyright (c) 2012-2023, GLP Schweiz. This file is part of
 #  hitobito_glp and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_glp.

--- a/app/domain/sorting_hat/song.rb
+++ b/app/domain/sorting_hat/song.rb
@@ -71,7 +71,7 @@ module SortingHat
     end
 
     def notify_parent_group(group)
-      if group.parent.email && group.parent.email != JGLP_EMAIL
+      if group.parent.email.present? && group.parent.email != JGLP_EMAIL
         Notifier.mitglied_joined(@person, group.parent.email, jglp?).deliver_later
       end
     end

--- a/app/domain/sorting_hat/song.rb
+++ b/app/domain/sorting_hat/song.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2020, GLP Schweiz. This file is part of
+#  Copyright (c) 2012-2023, GLP Schweiz. This file is part of
 #  hitobito_glp and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_glp.
@@ -16,7 +16,7 @@ module SortingHat
     end
 
     def sing
-      raise ArgumentError.new("Role #{@role} is not supported") unless role_valid?
+      raise ArgumentError, "Role #{@role} is not supported" unless role_valid?
 
       groups = finder.groups
       groups.each do |group|
@@ -78,7 +78,7 @@ module SortingHat
 
     def notify_layer_admins(groups)
       parent_groups = groups.flat_map(&:layer_hierarchy)
-      scope = Person.admin.notify_on_join.where(roles: { group: parent_groups } )
+      scope = Person.admin.notify_on_join.where(roles: { group: parent_groups })
       scope.distinct.find_each do |admin|
         Notifier.mitglied_joined_monitoring(@person, @role, admin.email, jglp?).deliver_later
       end

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -41,6 +41,13 @@ class Notifier < ApplicationMailer
       @subject = 'Achtung: Neue News-Anmeldung'
       @welcome = 'Es gibt eine neue Anmeldung für Partei-News.'
       @category = 'Medien & Dritte'
+    else
+      @subject = 'Achtung: Neue Anmeldung'
+      Raven.capture_exception(RuntimeError.new(<<~MESSAGE))
+        Kategorie "#{submitted_role}" wird von "mitglied_joined_monitoring" nicht direkt erwartet.
+
+        Person-ID: #{person.id}
+      MESSAGE
     end
 
     mail(to: email, subject: @subject)

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -1,52 +1,52 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2019, GLP Schweiz. This file is part of
+#  Copyright (c) 2012-2023, GLP Schweiz. This file is part of
 #  hitobito_glp and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_glp.
 
 
 class Notifier < ApplicationMailer
-  def zip_code_changed person, email
+  def zip_code_changed(person, email)
     @person = person
     mail(to: email)
   end
 
-  def mitglied_left attrs, email
+  def mitglied_left(attrs, email)
     @person = Person.new(attrs)
     mail(to: email)
   end
 
-  def mitglied_joined person, email, jglp
+  def mitglied_joined(person, email, jglp)
     @person = person
     @preferred_language = preferred_language(person)
     @jglp = jglp
-    mail(to: email, subject: "Achtung: Neues Mitglied.")
+    mail(to: email, subject: 'Achtung: Neues Mitglied.')
   end
 
-  def mitglied_joined_monitoring person, submitted_role, email, jglp
+  def mitglied_joined_monitoring(person, submitted_role, email, jglp) # rubocop:disable Metrics/MethodLength it would be better to create 3-4 separate methods out of this
     @person = person
     @category = submitted_role
     @preferred_language = preferred_language(person)
     @jglp = jglp
 
     case submitted_role
-    when "Mitglied"
-      @subject = "Achtung: Neues Mitglied"
-      @welcome = "Ein neues Mitglied hat sich registriert."
-    when "Sympathisant"
-      @subject = "Achtung: Neue/r Sympathisant/in"
-      @welcome = "Ein/e neue/r Sympathisant/in hat sich registriert."
-    when "Medien_und_dritte"
-      @subject = "Achtung: Neue News-Anmeldung"
-      @welcome = "Es gibt eine neue Anmeldung für Partei-News."
+    when 'Mitglied'
+      @subject = 'Achtung: Neues Mitglied'
+      @welcome = 'Ein neues Mitglied hat sich registriert.'
+    when 'Sympathisant'
+      @subject = 'Achtung: Neue/r Sympathisant/in'
+      @welcome = 'Ein/e neue/r Sympathisant/in hat sich registriert.'
+    when 'Medien_und_dritte'
+      @subject = 'Achtung: Neue News-Anmeldung'
+      @welcome = 'Es gibt eine neue Anmeldung für Partei-News.'
       @category = 'Medien & Dritte'
     end
 
     mail(to: email, subject: @subject)
   end
 
-  def welcome_mitglied person, locale
+  def welcome_mitglied(person, locale)
     @person = person
     @locale = locale
     I18n.locale = @locale
@@ -54,21 +54,21 @@ class Notifier < ApplicationMailer
     token = @person.generate_reset_password_token!
     @login_url = edit_person_password_url(reset_password_token: token)
 
-    mail(to: @person.email, subject: t(".subject"))
+    mail(to: @person.email, subject: t('.subject'))
   end
 
-  def welcome_sympathisant person, locale
+  def welcome_sympathisant(person, locale)
     @person = person
     @locale = locale
     I18n.locale = @locale
-    mail(to: @person.email, subject: t(".subject"))
+    mail(to: @person.email, subject: t('.subject'))
   end
 
-  def welcome_medien_und_dritte person, locale
+  def welcome_medien_und_dritte(person, locale)
     @person = person
     @locale = locale
     I18n.locale = @locale
-    mail(to: @person.email, subject: t(".subject"))
+    mail(to: @person.email, subject: t('.subject'))
   end
 
   def preferred_language(person)


### PR DESCRIPTION
There are supposedly some errors around mails for new members. This PR should bring a little more clarity to this.

One source of errors was the assumption that a missing email evaluates to `nil`, which in many cases is not true. If a group does not have an email, it may be an empty string, which would be trueish.

Another potential problem is that some mails might not have a subject, increasing their likelihood of being treated as spam. Fun, but not fun enough to keep around.