### PR TITLE
Repair admin notifications

### DIFF
--- a/app/domain/sorting_hat/finder.rb
+++ b/app/domain/sorting_hat/finder.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2020, GLP Schweiz. This file is part of
+#  Copyright (c) 2012-2023, GLP Schweiz. This file is part of
 #  hitobito_glp and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_glp.
@@ -65,9 +65,12 @@ module SortingHat
       @jglp_root ||= without_deleted.find_by(zip_codes: SortingHat::JGLP_ZIP_CODE)
     end
 
-    # rubocop:disable Metrics/LineLength
     def subtree_jglp
-      jglp_root ? without_deleted.where('lft > ? AND rgt < ?', jglp_root.lft, jglp_root.rgt) : Group.none
+      if jglp_root
+        without_deleted.where('lft > ? AND rgt < ?', jglp_root.lft, jglp_root.rgt)
+      else
+        Group.none
+      end
     end
 
     def foreign?

--- a/app/domain/sorting_hat/finder.rb
+++ b/app/domain/sorting_hat/finder.rb
@@ -21,7 +21,7 @@ module SortingHat
                elsif !foreign?
                  find_for_zip(root.descendants.where.not(id: subtree_jglp))
                end
-      groups.presence || fallback
+      Array.wrap(groups.presence || fallback)
     end
 
     private

--- a/app/domain/sorting_hat/song.rb
+++ b/app/domain/sorting_hat/song.rb
@@ -77,11 +77,15 @@ module SortingHat
     end
 
     def notify_layer_admins(groups)
-      parent_groups = groups.flat_map(&:layer_hierarchy)
-      scope = Person.admin.notify_on_join.where(roles: { group: parent_groups })
-      scope.distinct.find_each do |admin|
-        Notifier.mitglied_joined_monitoring(@person, @role, admin.email, jglp?).deliver_later
+      layer_admins(groups).pluck(:email).each do |email|
+        Notifier.mitglied_joined_monitoring(@person, @role, email, jglp?).deliver_later
       end
+    end
+
+    def layer_admins(groups)
+      Person.admin.notify_on_join
+            .where(roles: { group: groups.flat_map(&:layer_hierarchy) })
+            .distinct
     end
   end
 end


### PR DESCRIPTION
This addresses several problems I ran into when testing this manually:

- `SortingHat::Finder#groups` returned either a group or an array of groups, now it is always an Array
- `SortingHat::Song#notify_layer_admins` did more than I could comprehend. There I split it into two methods. After doing that, I saw that I could change the loop to not loop over `Person`-instances, but extract the emails and just loop over those.
