### PR TITLE
Adapt signature to core-change

### DIFF
--- a/app/controllers/glp/person/history_controller.rb
+++ b/app/controllers/glp/person/history_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2022, GLP Schweiz. This file is part of
+#  Copyright (c) 2022-2024, GLP Schweiz. This file is part of
 #  hitobito_glp and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_glp.
@@ -9,7 +9,7 @@ module Glp
   module Person::HistoryController
     extend ActiveSupport::Concern
 
-    def fetch_roles
+    def fetch_roles(*scopes)
       return super if donor_visible?
 
       super.reject { |r| r.type == ::Group::Spender::Spender.sti_name }


### PR DESCRIPTION
With this, the history of a person is viewable again.

See also: https://sentry.puzzle.ch/pitc/hitobito-backend/issues/65739/