### PR TITLE
Configure PaperTrail explicitely in spec

### DIFF
--- a/lib/hitobito_glp/wagon.rb
+++ b/lib/hitobito_glp/wagon.rb
@@ -26,8 +26,7 @@ module HitobitoGlp
       Person.include Glp::Person
       Group.include Glp::Group
 
-      # Skips paper_trail for this role type
-      PaperTrail.request.disable_model(Group::Spender::Spender)
+      HitobitoGlp::Wagon.configure_paper_trail!
 
       PersonDecorator.include Glp::PersonDecorator
       GroupDecorator.prepend Glp::GroupDecorator
@@ -100,6 +99,11 @@ module HitobitoGlp
           resource '*', headers: :any, methods: [:get, :post, :options]
         end
       end
+    end
+
+    def self.configure_paper_trail!
+      # Skips paper_trail for this role type
+      PaperTrail.request.disable_model(Group::Spender::Spender)
     end
 
     private

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2022, GLP Schweiz. This file is part of
+#  Copyright (c) 2022-2024, GLP Schweiz. This file is part of
 #  hitobito_glp and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_glp.
@@ -12,6 +12,10 @@ describe Role do
     let!(:person) { people(:admin) }
     let!(:donor_group) { Fabricate(Group::Spender.to_s, parent: groups(:root)) }
     let!(:donor) { Fabricate(Group::Spender::Spender.to_s, group: donor_group).person }
+
+    before do
+      HitobitoGlp::Wagon.configure_paper_trail!
+    end
 
     context 'on non donor role' do
       it 'sets main on create' do


### PR DESCRIPTION
The request_store is seemingly not persisted in specs, it resets the paper_trail-config if a request is fired.

You can use `rspec ./spec/api/graphiti_schema_spec.rb ./spec/models/role_spec.rb --seed 25740` to verify.