### PR TITLE
Disable paper trail for good and add specs

### DIFF
--- a/app/models/glp/role.rb
+++ b/app/models/glp/role.rb
@@ -9,6 +9,8 @@ module Glp::Role
   extend ActiveSupport::Concern
 
   included do
+    paper_trail_options[:unless] = proc { |r| r.type.constantize == Group::Spender::Spender }
+
     def touch_person
       person.paper_trail.save_with_version if type.constantize != Group::Spender::Spender
     end

--- a/lib/hitobito_glp/wagon.rb
+++ b/lib/hitobito_glp/wagon.rb
@@ -26,8 +26,6 @@ module HitobitoGlp
       Role.include Glp::Role
       Group.include Glp::Group
 
-      HitobitoGlp::Wagon.configure_paper_trail!
-
       PersonDecorator.include Glp::PersonDecorator
       GroupDecorator.prepend Glp::GroupDecorator
 
@@ -99,11 +97,6 @@ module HitobitoGlp
           resource "*", headers: :any, methods: [:get, :post, :options]
         end
       end
-    end
-
-    def self.configure_paper_trail!
-      # Skips paper_trail for this role type
-      PaperTrail.request.disable_model(Group::Spender::Spender)
     end
 
     private

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -13,10 +13,6 @@ describe Role do
     let!(:donor_group) { Fabricate(Group::Spender.to_s, parent: groups(:root)) }
     let!(:donor) { Fabricate(Group::Spender::Spender.to_s, group: donor_group).person }
 
-    before do
-      HitobitoGlp::Wagon.configure_paper_trail!
-    end
-
     context "on non donor role" do
       it "sets main on create" do
         # Changes by 2 because of role creation and role assignment to person
@@ -48,6 +44,16 @@ describe Role do
       it "does not set main on create" do
         expect do
           role = Group::Spender::Spender.new
+          role.group = donor_group
+          role.person = person
+          role.save!
+        end.to_not change { PaperTrail::Version.count }
+      end
+
+      it "does not set main on create, even when role type is set late" do
+        expect do
+          role = Role.new
+          role.type = Group::Spender::Spender.to_s
           role.group = donor_group
           role.person = person
           role.save!


### PR DESCRIPTION
Try harder to make sure no Spender role ever gets paper trailed

When searching the versions table in the DB with `item_type='Role' and event='create' and object_changes LIKE '%Spender%'`, we noticed there were some log entries still created when creating Spender roles. The rows in question have been deleted manually from the database now.

Refs hitobito/hitobito_sbv#92