### PR TITLE
Migrate from raven to sentry gem

### DIFF
--- a/app/mailers/notifier_mailer.rb
+++ b/app/mailers/notifier_mailer.rb
@@ -42,11 +42,10 @@ class NotifierMailer < ApplicationMailer
       @category = "Medien & Dritte"
     else
       @subject = "Achtung: Neue Anmeldung"
-      Raven.capture_exception(RuntimeError.new(<<~MESSAGE))
-        Kategorie "#{submitted_role}" wird von "mitglied_joined_monitoring" nicht direkt erwartet.
-
-        Person-ID: #{person.id}
-      MESSAGE
+      Sentry.with_scope do |scope|
+        scope.set_context(category: submitted_role, person_id: person.id)
+        Sentry.capture_message("Unerwartete Kategorie in 'mitglied_joined_monitoring'")
+      end
     end
 
     mail(to: email, subject: @subject)


### PR DESCRIPTION
Raven is only used in one place. I added the dynamic values as context to the captured message.

https://github.com/hitobito/hitobito/issues/3680